### PR TITLE
python-uinput_git.bb: Add a new dependency for udev

### DIFF
--- a/recipes-devtools/python/python-uinput_git.bb
+++ b/recipes-devtools/python/python-uinput_git.bb
@@ -2,7 +2,7 @@ SUMMARY = "uinput binding for python"
 SECTION = "devel/python"
 LICENSE = "GPLv3"
 LIC_FILES_CHKSUM = "file://COPYING;md5=f27defe1e96c2e1ecd4e0c9be8967949"
-DEPENDS = "python"
+DEPENDS = "python udev"
 RDEPENDS_${PN} = "python-core python-ctypes python-distutils"
 
 SRC_URI = "git://github.com/tuomasjjrasanen/python-uinput;branch=master;protocol=git"


### PR DESCRIPTION
Add a new dependency for udev as it provides libudev.so.

Signed-off-by: Leon Anavi leon.anavi@konsulko.com
